### PR TITLE
[RAINCATCH-1101] move passport integration to separate auth module

### DIFF
--- a/demo/auth/index.js
+++ b/demo/auth/index.js
@@ -1,0 +1,5 @@
+angular.module('wfm.auth', []);
+
+require('./passport');
+
+module.exports = 'wfm.auth';

--- a/demo/auth/package.json
+++ b/demo/auth/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@raincatcher/demo-auth-passport",
+  "version": "1.0.0",
+  "description": "Demo Passport auth service module",
+  "engines": {
+    "node": ">=4.4 <=6.10"
+  },
+  "keywords": [
+    "wfm"
+  ],
+  "license": "MIT",
+  "author": "feedhenry-raincatcher@redhat.com",
+  "dependencies": {
+    "@raincatcher/logger": "1.0.0",
+    "angular": "1.6.1",
+    "fh-js-sdk": "2.18.6"
+  },
+  "devDependencies": {
+    "browserify": "^14.4.0",
+    "browserify-shim": "^3.8.14"
+  }
+}

--- a/demo/auth/passport.js
+++ b/demo/auth/passport.js
@@ -2,9 +2,9 @@ var $fh = require('fh-js-sdk');
 var logger = require('@raincatcher/logger').logger;
 var ConsoleLogger = require('@raincatcher/logger').ConsoleLogger;
 var setLogger = require('@raincatcher/logger').setLogger;
+setLogger(new ConsoleLogger());
 
 $fh.init({}, function() {
-  setLogger(new ConsoleLogger());
   var passport = {
     loadUserProfile: function($http, $window) {
       var req = {
@@ -44,5 +44,5 @@ $fh.init({}, function() {
     return passport;
   });
 }, function(err) {
-
+  logger.error('An error occurred when initializing $fh', err);
 });

--- a/demo/auth/passport.js
+++ b/demo/auth/passport.js
@@ -6,7 +6,7 @@ var setLogger = require('@raincatcher/logger').setLogger;
 $fh.init({}, function() {
   setLogger(new ConsoleLogger());
   var passport = {
-    getProfile: function($http, $window) {
+    loadUserProfile: function($http, $window) {
       var req = {
         method: 'GET',
         url: $fh.getCloudURL() + '/profile'
@@ -22,6 +22,9 @@ $fh.init({}, function() {
         }
         return err;
       });
+    },
+    hasResourceRole: function(role) {
+      // TODO
     },
     logout: function($http, $window) {
       var req = {

--- a/demo/auth/passport.js
+++ b/demo/auth/passport.js
@@ -1,0 +1,45 @@
+var $fh = require('fh-js-sdk');
+var logger = require('@raincatcher/logger').logger;
+var ConsoleLogger = require('@raincatcher/logger').ConsoleLogger;
+var setLogger = require('@raincatcher/logger').setLogger;
+
+$fh.init({}, function() {
+  setLogger(new ConsoleLogger());
+  var passport = {
+    getProfile: function($http, $window) {
+      var req = {
+        method: 'GET',
+        url: $fh.getCloudURL() + '/profile'
+      };
+      return $http(req, {withCredentials: true}).then(function (res) {
+        return res.data;
+      }, function (err) {
+        if (err.status === 401) {
+          $window.location = $fh.getCloudURL() + '/login';
+        }
+        if (err.status === 403) {
+          logger.error('Forbidden');
+        }
+        return err;
+      });
+    },
+    logout: function($http, $window) {
+      var req = {
+        method: 'GET',
+        url: $fh.getCloudURL() + '/logout'
+      };
+
+      return $http(req, {withCredentials: true}).then(function(res) {
+        $window.location = $fh.getCloudURL() + '/login';
+      }, function(err) {
+        logger.error('An error occurred when logging out', err);
+      });
+    }
+  };
+
+  angular.module('wfm.auth').factory('passport', function() {
+    return passport;
+  });
+}, function(err) {
+
+});

--- a/demo/mobile/package.json
+++ b/demo/mobile/package.json
@@ -19,6 +19,7 @@
     "@raincatcher/workflow-angular": "1.0.0",
     "@raincatcher/workorder-angular": "1.0.0",
     "@raincatcher/vehicle-inspection": "1.0.0",
+    "@raincatcher/demo-auth-passport": "1.0.0",
     "@raincatcher/demo-sync": "1.0.0",
     "@raincatcher/demo-wfm": "1.0.0",
     "angular": "1.6.4",

--- a/demo/mobile/src/app/app.js
+++ b/demo/mobile/src/app/app.js
@@ -9,6 +9,7 @@ var module = angular.module('wfm-mobile', [
   require('angular-ui-router'),
   require('angular-material'),
   require('./services'),
+  require('@raincatcher/demo-auth-passport'),
   require('@raincatcher/demo-wfm'),
   require('@raincatcher/demo-sync'),
   // Set of the data services

--- a/demo/mobile/src/app/initialisation/config.js
+++ b/demo/mobile/src/app/initialisation/config.js
@@ -17,8 +17,8 @@ function createMainAppRoute($stateProvider, $urlRouterProvider) {
 }
 
 angular.module('wfm-mobile').config(['$stateProvider', '$urlRouterProvider', createMainAppRoute]).controller('mainController', [
-  '$rootScope', '$scope', '$state', '$mdSidenav', 'userService', '$http', '$window', 'Auth',
-  function($rootScope, $scope, $state, $mdSidenav, userService, $http, $window, Auth) {
+  '$rootScope', '$scope', '$state', '$mdSidenav', 'passport', '$http', '$window', 'Auth'
+  function($rootScope, $scope, $state, $mdSidenav, passport, $http, $window, Auth) {
 
     // return user profile from keycloak
     if (Auth.keycloak) {
@@ -37,7 +37,7 @@ angular.module('wfm-mobile').config(['$stateProvider', '$urlRouterProvider', cre
       });
     } else {
       // return user profile from passport
-      userService.getProfile($http, $window).then(function(profileData) {
+      passport.getProfile($http, $window).then(function(profileData) {
         $scope.profileData = profileData;
       });
     }
@@ -64,16 +64,7 @@ angular.module('wfm-mobile').config(['$stateProvider', '$urlRouterProvider', cre
       if (Auth.keycloak) {
         Auth.keycloak.logout();
       } else {
-        var req = {
-          method: 'GET',
-          url: fh.getCloudURL() + '/logout'
-        };
-
-        return $http(req, {withCredentials: true}).then(function(res) {
-          $window.location = fh.getCloudURL() + '/login';
-        }, function(err) {
-          console.log('error logging out', err);
-        });
+        passport.logout($http, $window);
       }
     };
   }]);

--- a/demo/mobile/src/app/initialisation/config.js
+++ b/demo/mobile/src/app/initialisation/config.js
@@ -17,8 +17,8 @@ function createMainAppRoute($stateProvider, $urlRouterProvider) {
 }
 
 angular.module('wfm-mobile').config(['$stateProvider', '$urlRouterProvider', createMainAppRoute]).controller('mainController', [
-  '$rootScope', '$scope', '$state', '$mdSidenav', 'passport', '$http', '$window', 'Auth'
-  function($rootScope, $scope, $state, $mdSidenav, passport, $http, $window, Auth) {
+  '$rootScope', '$scope', '$state', '$mdSidenav', '$http', '$window', 'Auth'
+  function($rootScope, $scope, $state, $mdSidenav, $http, $window, Auth) {
 
     // return user profile from keycloak
     if (Auth.keycloak) {
@@ -37,7 +37,7 @@ angular.module('wfm-mobile').config(['$stateProvider', '$urlRouterProvider', cre
       });
     } else {
       // return user profile from passport
-      passport.getProfile($http, $window).then(function(profileData) {
+      Auth.passport.loadUserProfile($http, $window).then(function(profileData) {
         $scope.profileData = profileData;
       });
     }
@@ -64,7 +64,7 @@ angular.module('wfm-mobile').config(['$stateProvider', '$urlRouterProvider', cre
       if (Auth.keycloak) {
         Auth.keycloak.logout();
       } else {
-        passport.logout($http, $window);
+        Auth.passport.logout($http, $window);
       }
     };
   }]);

--- a/demo/mobile/src/app/initialisation/config.js
+++ b/demo/mobile/src/app/initialisation/config.js
@@ -17,7 +17,7 @@ function createMainAppRoute($stateProvider, $urlRouterProvider) {
 }
 
 angular.module('wfm-mobile').config(['$stateProvider', '$urlRouterProvider', createMainAppRoute]).controller('mainController', [
-  '$rootScope', '$scope', '$state', '$mdSidenav', '$http', '$window', 'Auth'
+  '$rootScope', '$scope', '$state', '$mdSidenav', '$http', '$window', 'Auth',
   function($rootScope, $scope, $state, $mdSidenav, $http, $window, Auth) {
 
     // return user profile from keycloak

--- a/demo/mobile/src/app/services/userService.js
+++ b/demo/mobile/src/app/services/userService.js
@@ -19,24 +19,6 @@ UserService.prototype.readUser = function readUser(userId) {
   });
 };
 
-UserService.prototype.getProfile = function($http, $window) {
-  var req = {
-    method: 'GET',
-    url: fh.getCloudURL() + '/profile'
-  };
-  return $http(req, {withCredentials: true}).then(function(res) {
-    return res.data;
-  }, function(err) {
-    if (err.status === 401) {
-      $window.location = fh.getCloudURL() + '/login';
-    }
-    if (err.status === 403) {
-      console.log('Forbidden')
-    }
-    return err;
-  });
-};
-
 UserService.prototype.listUsers = function listUsers() {
   return Promise.all(this.readUser());
 };

--- a/demo/sync/syncServices.js
+++ b/demo/sync/syncServices.js
@@ -1,7 +1,7 @@
 var config = require('./config.json');
 var _ = require('lodash');
-angular.module('wfm.sync',[]).service('syncService', ['$http', '$window', 'syncPool', 'userService', function($http, $window, syncPool, userService) {
-  return userService.getProfile($http, $window)
+angular.module('wfm.sync',[]).service('syncService', ['$http', '$window', 'syncPool', 'passport', function($http, $window, syncPool, passport) {
+  return passport.getProfile($http, $window)
     .then(syncPool.syncManagerMap);
 }]);
 

--- a/demo/sync/syncServices.js
+++ b/demo/sync/syncServices.js
@@ -1,8 +1,17 @@
 var config = require('./config.json');
 var _ = require('lodash');
-angular.module('wfm.sync',[]).service('syncService', ['$http', '$window', 'syncPool', 'passport', function($http, $window, syncPool, passport) {
-  return passport.getProfile($http, $window)
-    .then(syncPool.syncManagerMap);
+angular.module('wfm.sync',[]).service('syncService', ['$http', '$window', 'syncPool', 'Auth', function($http, $window, syncPool, Auth) {
+  if (Auth.keycloak) {
+    // retrieve the users profile from keycloak
+    return Auth.keycloak.loadUserProfile()
+      .success(syncPool.syncManagerMap)
+      .error(function(err) {
+        console.log("Failed to Load User Profile", err);
+      });
+    } else {
+    // return user profile from passport
+    return Auth.passport.loadUserProfile($http, $window).then(syncPool.syncManagerMap);
+  }
 }]);
 
 // Generating common data repositories


### PR DESCRIPTION
## Motivation
Passport will need to be integrated with both the mobile and portal app. An auth module which can be consumed by both the mobile and portal demo application needs to be created to reduce code duplication.

## Description
Moved the current Passport integration in the mobile app to a separate auth module which the mobile and portal can use.

## Progress
- [x] Create a separate demo auth module
- [x] Move getProfile and logout implementation to the auth module
- [x] Integrate the demo auth module with the mobile app
- [ ] Address comments from PR review (https://github.com/feedhenry-raincatcher/raincatcher-angularjs/pull/24)

## Additional Notes
Related JIRA Ticket - https://issues.jboss.org/browse/RAINCATCH-1101
